### PR TITLE
Use printf instead of echo

### DIFF
--- a/autoload/fzf_checkout.vim
+++ b/autoload/fzf_checkout.vim
@@ -78,7 +78,7 @@ function! fzf_checkout#list(bang, type)
   " list everything else,
   " remove empty lines.
   let l:source =
-        \ 'echo -e "$(' . l:git_cmd . ' --list ' . l:previous . ')"\\n' .
+        \ 'printf "$(' . l:git_cmd . ' --list ' . l:previous . ')"\\n' .
         \ '"$(' . l:git_cmd . ' | ' . l:filter . ')" | ' .
         \ ' sed "/^\s*$/d"'
   call fzf#run(fzf#wrap(


### PR DESCRIPTION
The behaviour of echo isn't deterministic,
it changes between shells (bash 4, bash 5, zsh, etc).
printf is more standard https://stackoverflow.com/questions/8467424/echo-newline-in-bash-prints-literal-n/8467449#8467449

Fixes #4