### PR TITLE
Add an option to disable move previous ref on top

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Key used to create a branch locally (`git checkout -b branch`).
 let g:fzf_checkout_track_key = 'ctrl-n'
 ```
 
+## g:fzf_checkout_previous_ref_first
+
+Display previously used branch first independent of specified sorting.
+
+```vim
+let g:fzf_checkout_previous_ref_first = v:true
+```
+
 ## g:fzf_checkout_execute
 
 Command used to execute the checkout, options are:

--- a/autoload/fzf_checkout.vim
+++ b/autoload/fzf_checkout.vim
@@ -130,11 +130,13 @@ function! fzf_checkout#list(bang, type)
   call s:remove_branch(l:git_output, escape(l:current, '/'))
   call s:remove_branch(l:git_output, '\(origin/\)\?HEAD')
 
-  " Put previous ref first
-  let l:previous = s:get_previous_ref()
-  if !empty(l:previous)
-    if (s:remove_branch(l:git_output, escape(l:previous, '/')))
-      call insert(l:git_output, system(l:git_cmd .. ' --list ' .. l:previous), 0)
+  if g:fzf_checkout_previous_ref_first
+    " Put previous ref first
+    let l:previous = s:get_previous_ref()
+    if !empty(l:previous)
+      if (s:remove_branch(l:git_output, escape(l:previous, '/')))
+        call insert(l:git_output, system(l:git_cmd .. ' --list ' .. l:previous), 0)
+      endif
     endif
   endif
 

--- a/plugin/fzf_checkout.vim
+++ b/plugin/fzf_checkout.vim
@@ -6,6 +6,7 @@ let g:fzf_checkout_track_execute = get(g:, 'fzf_checkout_track_execute', 'system
 let g:fzf_checkout_track_key = get(g:, 'fzf_checkout_track_key', 'alt-enter')
 let g:fzf_checkout_create_execute = get(g:, 'fzf_checkout_create_execute', 'system')
 let g:fzf_checkout_create_key = get(g:, 'fzf_checkout_create_key', 'ctrl-n')
+let g:fzf_checkout_previous_ref_first = get(g:, 'fzf_checkout_previous_ref_first', v:true)
 
 
 let s:prefix = get(g:, 'fzf_command_prefix', '')


### PR DESCRIPTION
 Make moving previous ref on top optional. If you using something like `--sort=-committerdate` this feature may be not needed and can save time on large repos or Windows (launching external processes on this OS is extremely slow).