### PR TITLE
Add support to change the sorting of the branches and tags

### DIFF
--- a/autoload/fzf_checkout.vim
+++ b/autoload/fzf_checkout.vim
@@ -1,6 +1,6 @@
 " See valid atoms in
 " https://github.com/git/git/blob/076cbdcd739aeb33c1be87b73aebae5e43d7bcc5/ref-filter.c#L474
-let s:sort = get(g:,"fzf_checkout_sort","refname:short")
+let s:sort = get(g:,'fzf_checkout_sort','refname:short')
 let s:format = shellescape(
       \ '%(color:yellow bold)%(refname:short)  ' .
       \ '%(color:reset)%(color:green)%(subject) ' .

--- a/autoload/fzf_checkout.vim
+++ b/autoload/fzf_checkout.vim
@@ -1,5 +1,6 @@
 " See valid atoms in
 " https://github.com/git/git/blob/076cbdcd739aeb33c1be87b73aebae5e43d7bcc5/ref-filter.c#L474
+let s:sort = get(g:,"fzf_checkout_sort","refname:short")
 let s:format = shellescape(
       \ '%(color:yellow bold)%(refname:short)  ' .
       \ '%(color:reset)%(color:green)%(subject) ' .
@@ -198,9 +199,10 @@ function! fzf_checkout#list(bang, type, options, deprecated) abort
     let l:prompt = l:actions[l:action]['prompt']
   endif
 
-  let l:git_cmd = printf('%s %s --color=always --sort=refname:short --format=%s %s',
+  let l:git_cmd = printf('%s %s --color=always --sort=%s --format=%s %s',
         \ g:fzf_checkout_git_bin,
         \ l:subcommand,
+        \ s:sort,
         \ s:format,
         \ g:fzf_checkout_git_options
         \)

--- a/doc/fzf-checkout.txt
+++ b/doc/fzf-checkout.txt
@@ -210,4 +210,15 @@ Set it to `v:false` if you want to have full control over the defined actions.
    let g:fzf_checkout_merge_settings= v:true
 <
 
+                                               *g:fzf_checkout_sort*
+g:fzf_checkout_sort
+
+Set a custom sorting algorithe for the branches and tags as defined by git.
+More details are present in the documentation of `git`.
+The default value is `refname:short`.
+
+>
+   let g:fzf_checkout_sort = 'refname'
+<
+
 vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
This option allows the user to set the sorting of the branches and tags.

By default, the sort is done with the `:short` keyword, which will place at the end local branches with a name starting with a letter after `o` (for a remote called `origin`).
By using, for example, `refname` instead, we will use the full path of the branch in the sorting algorithem, hence having the local branch first (they start with `head`), then the remotes, by remote name then branch name.

![Screenshot from 2021-03-10 17-40-07](https://user-images.githubusercontent.com/9901302/110664495-bb8d3280-81c7-11eb-8059-e7aa54b1b114.png)

Note the `zzzzee_new_branch` in the screen capture.

This will also let the user use other ways to sort, like `authordate` or mutiple fields.

The configuration is done in the `vim rc` file with:

```
let g:fzf_checkout_sort = "refname"
```

Note: this PR is will create a conflict with the other PR #51, I will solve the conflict if both are merged.
