### PR TITLE
Draft: Add support for automatic branch tracking

### DIFF
--- a/autoload/fzf_checkout.vim
+++ b/autoload/fzf_checkout.vim
@@ -66,6 +66,7 @@ function! fzf_checkout#execute(type, action, lines) abort
       let l:branch = trim(shellescape(split(a:lines[2])[0]), l:trimchars)
     endif
   endif
+  let l:branchlo = trim(l:branch,"origin/")
 
   let l:required = l:actions[l:action]['required']
 
@@ -95,6 +96,7 @@ function! fzf_checkout#execute(type, action, lines) abort
   if type(l:Execute_command) == v:t_string
     let l:Execute_command = substitute(l:Execute_command, '{git}', g:fzf_checkout_git_bin, 'g')
     let l:Execute_command = substitute(l:Execute_command, '{branch}', l:branch, 'g')
+    let l:Execute_command = substitute(l:Execute_command, '{branchlo}', l:branchlo, 'g')
     let l:Execute_command = substitute(l:Execute_command, '{tag}', l:branch, 'g')
     let l:Execute_command = substitute(l:Execute_command, '{input}', l:input, 'g')
     execute l:Execute_command

--- a/autoload/fzf_checkout.vim
+++ b/autoload/fzf_checkout.vim
@@ -66,7 +66,7 @@ function! fzf_checkout#execute(type, action, lines) abort
       let l:branch = trim(shellescape(split(a:lines[2])[0]), l:trimchars)
     endif
   endif
-  let l:branchlo = trim(l:branch,"origin/")
+  let l:branchlo = substitute(l:branch, '^origin/', '', 'g')
 
   let l:required = l:actions[l:action]['required']
 

--- a/plugin/fzf_checkout.vim
+++ b/plugin/fzf_checkout.vim
@@ -7,7 +7,7 @@ let g:fzf_checkout_merge_settings = get(g:, 'fzf_checkout_merge_settings', v:tru
 let s:branch_actions = {
       \ 'checkout': {
       \   'prompt': 'Checkout> ',
-      \   'execute': 'echo system("{git} checkout {branch}")',
+      \   'execute': 'echo system("{git} checkout -b {branchlo} --track {branch} || {git} checkout {branch}")',
       \   'multiple': v:false,
       \   'keymap': 'enter',
       \   'required': ['branch'],


### PR DESCRIPTION
This is a draft related to the issue #50. Only to have a tracked discussion on how to implement this feature.

The idea is to try first to create a new branch with remote tracking; if the branch already exists, it will fail and trigger the second command doing a normal `git checkout`.

I'm using this in a bash script to do fzf branch managment ( :smile: ) since years and it works fine.